### PR TITLE
fix: use a fixed version for bson dependency

### DIFF
--- a/bson/mod.ts
+++ b/bson/mod.ts
@@ -1,2 +1,2 @@
 // @deno-types='./bson.d.ts'
-export * from "https://cdn.skypack.dev/bson";
+export * from "https://cdn.skypack.dev/bson@v4.5.3";


### PR DESCRIPTION
Currently we always import latest version of bson that is not safe