### PR TITLE
docs: recommend noCursorTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ const all_users = await users.find({ username: { $ne: null } }).toArray();
 const user1_id = await users.findOne({
   _id: new ObjectId("SOME OBJECTID STRING"),
 });
+
+// use the option { noCursorTimeout: false } if you are using a shared cluster
+// see https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/
+const user1 = await users.findOne({...},{ noCursorTimeout: false });
+const all_users = await users.find({...},{ noCursorTimeout: false }).toArray();
 ```
 
 ### Count


### PR DESCRIPTION
Updates the README.md to warn users of a shared cluster of mongoDB Atlas that they should use { noCursorTimeout: false } option due to the [limitations](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations) of the shared cluster 

Error without the option:
![image](https://user-images.githubusercontent.com/68438095/225515440-b5179365-9433-43b3-b3ca-f5614d8c5a42.png)
