### PR TITLE
fix insert operation return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# deno_mongo
+# arkiver-mongo
 
-> **deno_mongo** is a **MongoDB** database driver developed for Deno. supports
+> **arkiver-mongo** is a fork of **deno_mongo** which is a **MongoDB** database driver developed for Deno. supports
 > Deno Deploy as well.
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# arkiver-mongo
+# deno_mongo
 
-> **arkiver-mongo** is a fork of **deno_mongo** which is a **MongoDB** database driver developed for Deno. supports
+> **deno_mongo** is a **MongoDB** database driver developed for Deno. supports
 > Deno Deploy as well.
 
 <div align="center">

--- a/src/collection/collection.ts
+++ b/src/collection/collection.ts
@@ -157,8 +157,8 @@ export class Collection<T extends Document> {
     docs: InsertDocument<T> | InsertDocument<T>[],
     options?: InsertOptions,
   ) {
-    docs = Array.isArray(docs) ? docs : [docs];
-    return this.insertMany(docs, options);
+    const _docs = Array.isArray(docs) ? docs : [docs];
+    return this.insertMany(_docs, options);
   }
 
   async insertMany(
@@ -166,7 +166,7 @@ export class Collection<T extends Document> {
     options?: InsertOptions,
   ): Promise<
     {
-      insertedIds: (ObjectId | Required<InsertDocument<T>>["_id"])[];
+      insertedIds: Required<InsertDocument<T>>["_id"][];
       insertedCount: number;
     }
   > {

--- a/src/protocol/message.ts
+++ b/src/protocol/message.ts
@@ -145,7 +145,7 @@ export function deserializeMessage(
 function parseDocuments(buffer: Uint8Array): Document[] {
   let pos = 0;
   const docs = [];
-  const view = new DataView(buffer);
+  const view = new DataView(buffer.buffer);
   while (pos < buffer.byteLength) {
     const docLen = view.getInt32(pos, true);
     const doc = deserialize(buffer.slice(pos, pos + docLen));

--- a/src/types.ts
+++ b/src/types.ts
@@ -796,11 +796,7 @@ type Flatten<T> = T extends Array<infer Item> ? Item : T;
 
 type IsAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 
-export type InsertDocument<TDocument extends Document> =
-  & Omit<TDocument, "_id">
-  & {
-    _id?: TDocument["_id"] | ObjectId;
-  };
+export type InsertDocument<TDocument extends Document> = TDocument["_id"] extends {} ? TDocument : TDocument & { _id?: ObjectId };
 
 type KeysOfType<T, Type> = {
   [Key in keyof T]: NonNullable<T[Key]> extends Type ? Key : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -796,8 +796,9 @@ type Flatten<T> = T extends Array<infer Item> ? Item : T;
 
 type IsAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 
-// deno-lint-ignore ban-types
-export type InsertDocument<TDocument extends Document> = TDocument["_id"] extends {} ? TDocument : TDocument & { _id?: ObjectId };
+export type InsertDocument<TDocument extends Document> =
+  // deno-lint-ignore ban-types
+  TDocument["_id"] extends {} ? TDocument : TDocument & { _id?: ObjectId };
 
 type KeysOfType<T, Type> = {
   [Key in keyof T]: NonNullable<T[Key]> extends Type ? Key : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -797,8 +797,11 @@ type Flatten<T> = T extends Array<infer Item> ? Item : T;
 type IsAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 
 export type InsertDocument<TDocument extends Document> =
-  // deno-lint-ignore ban-types
-  TDocument["_id"] extends {} ? TDocument : TDocument & { _id?: ObjectId };
+  Extract<TDocument["_id"], ObjectId> extends ObjectId
+    ? Omit<TDocument, "_id"> & { _id?: TDocument["_id"] }
+    // deno-lint-ignore ban-types
+    : TDocument["_id"] extends {} ? TDocument
+    : TDocument & { _id?: ObjectId };
 
 type KeysOfType<T, Type> = {
   [Key in keyof T]: NonNullable<T[Key]> extends Type ? Key : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -796,6 +796,7 @@ type Flatten<T> = T extends Array<infer Item> ? Item : T;
 
 type IsAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 
+// deno-lint-ignore ban-types
 export type InsertDocument<TDocument extends Document> = TDocument["_id"] extends {} ? TDocument : TDocument & { _id?: ObjectId };
 
 type KeysOfType<T, Type> = {


### PR DESCRIPTION
This PR fixes the return type from insert operations. If a type was specified in the provided schema `_id` field, it uses that type, else it returns an `ObjectId` type. Before this, it returned a union of the type and `ObjectId`