### PR TITLE
use modern deno streams

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -19,4 +19,3 @@ export {
 export { crypto as stdCrypto } from "jsr:@std/crypto@^0.220.1/crypto";
 export { decodeBase64, encodeBase64 } from "jsr:@std/encoding@^0.220.1/base64";
 export { encodeHex } from "jsr:@std/encoding@^0.220.1/hex";
-export { BufReader, writeAll } from "jsr:@std/io@^0.220.1";

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -17,7 +17,7 @@ interface CommandTask {
 let nextRequestId = 0;
 
 export class WireProtocol {
-  conn: Deno.Conn;
+  #conn: Deno.Conn;
   #isPendingResponse = false;
   #isPendingRequest = false;
   #pendingResponses: Map<number, {
@@ -29,7 +29,7 @@ export class WireProtocol {
   #commandQueue: CommandTask[] = [];
 
   constructor(socket: Deno.Conn) {
-    this.conn = socket;
+    this.#conn = socket;
   }
 
   async connect() {
@@ -94,7 +94,7 @@ export class WireProtocol {
         ],
       });
 
-      const { write, releaseLock } = this.conn.writable.getWriter();
+      const { write, releaseLock } = this.#conn.writable.getWriter();
       await write(buffer);
       releaseLock();
     }
@@ -125,7 +125,7 @@ export class WireProtocol {
   private async read_socket(
     b: number,
   ): Promise<Uint8Array | undefined> {
-    const reader = this.conn.readable.getReader({ mode: "byob" });
+    const reader = this.#conn.readable.getReader({ mode: "byob" });
     const { value } = await reader.read(new Uint8Array(b));
     reader.releaseLock();
     return value;

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -110,6 +110,8 @@ export class WireProtocol {
         throw new MongoDriverError("Invalid response header");
       }
       const header = parseHeader(headerBuffer);
+      let bodyBytes = header.messageLength - 16;
+      if (bodyBytes < 0) bodyBytes = 0;
       const bodyBuffer = await this.read_socket(header.messageLength - 16);
       if (!bodyBuffer) {
         throw new MongoDriverError("Invalid response body");

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -94,9 +94,9 @@ export class WireProtocol {
         ],
       });
 
-      const { write, releaseLock } = this.#conn.writable.getWriter();
-      await write(buffer);
-      releaseLock();
+      const w = this.#conn.writable.getWriter();
+      await w.write(buffer);
+      w.releaseLock();
     }
     this.#isPendingRequest = false;
   }


### PR DESCRIPTION
instead of using the Deno.Reader and Deno.Writer apis, [which are going to be removed](https://docs.deno.com/runtime/manual/advanced/migrate_deprecations) in Deno 2.0, this PR moves towards using the ReadableStream and Writeable stream interfaces already available on the Deno.Conn interface. additionally, this removed the dependency on @std/io, which lightens the package a bit too

edit: not sure why tests are failing, they passed earlier when i was working on them locally