### PR TITLE
fix: reject promise if deserializeMessage throws

### DIFF
--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -116,10 +116,14 @@ export class WireProtocol {
       if (!bodyBuffer) {
         throw new MongoDriverError("Invalid response body");
       }
-      const reply = deserializeMessage(header, bodyBuffer);
       const pendingMessage = this.#pendingResponses.get(header.responseTo);
       this.#pendingResponses.delete(header.responseTo);
-      pendingMessage?.resolve(reply);
+      try {
+        const reply = deserializeMessage(header, bodyBuffer);
+        pendingMessage?.resolve(reply);
+      } catch (e) {
+        pendingMessage?.reject(e)
+      }
     }
     this.#isPendingResponse = false;
   }

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -126,7 +126,7 @@ export class WireProtocol {
         const reply = deserializeMessage(header, bodyBuffer);
         pendingMessage?.resolve(reply);
       } catch (e) {
-        pendingMessage?.reject(e)
+        pendingMessage?.reject(e);
       }
     }
     this.#isPendingResponse = false;


### PR DESCRIPTION
if deserializeMessage throws for any reason (such as a BSONError), the pendingMessage promise will never resolve. this PR changes this behavior so that the promise will reject if there's an error thrown