### PR TITLE
chore: bump web_bson version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -15,7 +15,7 @@ export {
   serialize,
   Timestamp,
   UUID,
-} from "jsr:@lucsoft/web-bson@^0.3.1";
+} from "jsr:@lucsoft/web-bson@^0.4.0";
 export { crypto as stdCrypto } from "jsr:@std/crypto@^1.0.3/crypto";
 export { decodeBase64, encodeBase64 } from "jsr:@std/encoding@^1.0.5/base64";
 export { encodeHex } from "jsr:@std/encoding@^1.0.5/hex";


### PR DESCRIPTION
this bumps the version of web_bson used to the latest one, fixing some weird issues i've ran into