### PR TITLE
add dependency update workflow

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -1,0 +1,17 @@
+name: deps
+
+on:
+  schedule:
+    - cron: "0 23 * * *"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: williamhorning/deno-outdated-action@v1
+        with:
+          branch_name: "bump-version"
+          commit_message: "chores: update Deno dependencies"
+          deno_version: "2.x"
+          pull_request_title: "chore: update Deno dependencies"

--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Deno
         uses: denolib/setup-deno@master
         with:
-          deno-version: 1.x.x
+          deno-version: 2.x.x
 
       - name: Log versions
         run: |


### PR DESCRIPTION
this fixes #422 by adding a workflow that creates PRs that update dependency versions

additionally, this updates the publish workflow to use deno 2